### PR TITLE
Use async_forward_entry_setups

### DIFF
--- a/custom_components/enphase_envoy_custom/__init__.py
+++ b/custom_components/enphase_envoy_custom/__init__.py
@@ -123,7 +123,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         NAME: name,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
On HA 2023.3, this integration fails to load because it's using `async_setup_platforms`. See https://github.com/briancmpbll/home_assistant_custom_envoy/pull/50